### PR TITLE
Allow non-required fields to be blank

### DIFF
--- a/lib/kuali_toolbox/etl.rb
+++ b/lib/kuali_toolbox/etl.rb
@@ -179,6 +179,8 @@ module KualiCo::ETL
     end
     if opt[:default] && retval.empty?
       retval = opt[:default].to_s
+    elsif retval.empty?
+      return retval
     end
     if opt[:length] && retval.length > opt[:length].to_i
       detail = "#{opt[:name]}.length > #{opt[:length]}: '#{str}'-->'#{str[0..(opt[:length] - 1)]}'"

--- a/lib/kuali_toolbox/etl/grm.rb
+++ b/lib/kuali_toolbox/etl/grm.rb
@@ -179,6 +179,7 @@ module KualiCo::ETL::GRM
     #   `EMP_STAT_CD` varchar(40) COLLATE utf8_bin DEFAULT NULL,
     opt[:name]         = "EMP_STAT_CD" if opt[:name].nil?
     opt[:valid_values] = /^(A|D|L|N|P|R|S|T)$/i if opt[:valid_values].nil?
+    opt[:required]     = true
     return KualiCo::ETL::parse_flag str, opt
   end
 
@@ -192,6 +193,7 @@ module KualiCo::ETL::GRM
     #   `EMP_TYP_CD` varchar(40) COLLATE utf8_bin DEFAULT NULL,
     opt[:name]         = "EMP_TYP_CD" if opt[:name].nil?
     opt[:valid_values] = /^(N|O|P)$/i if opt[:valid_values].nil?
+    opt[:required]     = true
     return KualiCo::ETL::parse_flag str, opt
   end
 
@@ -218,6 +220,7 @@ module KualiCo::ETL::GRM
     opt[:name]         = "NM_TYP_CD" if opt[:name].nil?
     opt[:length]       = 4 if opt[:length].nil?
     opt[:valid_values] = /^(OTH|PRFR|PRM)$/i if opt[:valid_values].nil?
+    opt[:required]     = true
     return KualiCo::ETL::parse_flag str, opt
   end
 

--- a/spec/kuali_toolbox/etl/grm_spec.rb
+++ b/spec/kuali_toolbox/etl/grm_spec.rb
@@ -345,8 +345,8 @@ RSpec.describe "KualiCo::ETL::GRM" do
     end
 
     it "raises an TextParseError if the address_type_code is nil or empty" do
-      expect { GRM.parse_address_type_code(nil) }.to raise_error(TextParseError)
-      expect { GRM.parse_address_type_code("") }.to  raise_error(TextParseError)
+      expect(GRM.parse_address_type_code(nil)).to eq("")
+      expect(GRM.parse_address_type_code("")).to  eq("")
     end
 
     # <xs:maxLength value="3"/>
@@ -471,8 +471,8 @@ RSpec.describe "KualiCo::ETL::GRM" do
     end
 
     it "raises an TextParseError if the phone_type is nil or empty" do
-      expect { GRM.parse_phone_type(nil) }.to raise_error(TextParseError)
-      expect { GRM.parse_phone_type("") }.to  raise_error(TextParseError)
+      expect(GRM.parse_phone_type(nil)).to eq("")
+      expect(GRM.parse_phone_type("")).to  eq("")
     end
 
     # <xs:maxLength value="3"/>
@@ -536,8 +536,8 @@ RSpec.describe "KualiCo::ETL::GRM" do
     end
 
     it "raises an TextParseError if the email_type is nil or empty" do
-      expect { GRM.parse_email_type(nil) }.to raise_error(TextParseError)
-      expect { GRM.parse_email_type("") }.to  raise_error(TextParseError)
+      expect(GRM.parse_email_type(nil)).to eq("")
+      expect(GRM.parse_email_type("")).to  eq("")
     end
 
     # <xs:maxLength value="3"/>
@@ -587,8 +587,8 @@ RSpec.describe "KualiCo::ETL::GRM" do
     end
 
     it "raises an TextParseError if the citizenship_type is nil or empty" do
-      expect { GRM.parse_citizenship_type(nil) }.to raise_error(TextParseError)
-      expect { GRM.parse_citizenship_type("") }.to  raise_error(TextParseError)
+      expect(GRM.parse_citizenship_type(nil)).to eq("")
+      expect(GRM.parse_citizenship_type("")).to  eq("")
     end
 
     it "raises an TextParseError if length exceeds 1 character" do


### PR DESCRIPTION
Currently non-required fields are required to match length and valid regex portions of the parse_string method, despite being empty. This corrects that.